### PR TITLE
ci: skip new files in storage layout checks

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
+        if: steps.changed-contracts.outputs.contracts_modified_files != ''
         env:
-          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_modified_files }}
         run: |
           for CONTRACT in "$CHANGED_CONTRACTS"; do
             echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
+        if: steps.changed-libraries.outputs.libraries_modified_files != ''
         env:
-          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_modified_files }}
         run: |
           for DIAMOND_LIB in "$CHANGED_LIBS"; do
             echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt


### PR DESCRIPTION
Resolves #972

## Summary

- Restricts both storage-check matrices to Solidity files reported by `tj-actions/changed-files` as modified, not all changed files.
- Leaves newly added core contracts and `Lib*.sol` libraries out of the storage-check matrix, avoiding baseline artifact lookup for files that cannot have prior storage artifacts.
- Keeps edited existing contracts/libraries covered by the existing `foundry-storage-check` jobs.

## Why this approach

The storage checker compares against artifacts from the base branch. A newly added file cannot have a base-branch storage artifact, which is what produces the `No workflow run found with an artifact named...` failure. Using the action's `*_modified_files` outputs keeps the check focused on files that existed before and avoids adding a fragile base-ref lookup to the workflow.

## QA

| Scenario | Expected result |
| --- | --- |
| No storage updates / no in-scope modified files | CI passes; matrix output is empty and the storage job is skipped. |
| Existing storage update without collision | CI passes; modified file remains in the matrix and the storage checker runs. |
| Existing storage update with collision | CI fails; modified file remains in the matrix and the storage checker runs. |
| New contract or library added | CI passes; added files are absent from `*_modified_files`, so no missing baseline artifact is requested. |

## Validation

- Parsed both modified workflow YAML files locally with Ruby `YAML.load_file`.
- Ran `git diff --check`.
- Verified `tj-actions/changed-files@v42` defines the `modified_files` output used here.