### PR TITLE
fix: skip storage layout check for newly added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -26,17 +26,24 @@ jobs:
             contracts:
               - packages/contracts/src/dollar/core/*.sol
 
-      - name: Set contracts matrix
+      - name: Set contracts matrix (skip newly added contracts - no prior artifact to compare)
         id: set-matrix
         working-directory: packages/contracts
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          MODIFIED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_modified_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Only check modified contracts (not newly added ones)
+          # New contracts have no prior storage artifact to compare against
+          if [ -n "$MODIFIED_CONTRACTS" ]; then
+            for CONTRACT in $MODIFIED_CONTRACTS; do
+              echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+            done
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -64,4 +71,3 @@ jobs:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -30,17 +30,24 @@ jobs:
             libraries:
               - packages/contracts/src/dollar/libraries/Lib*.sol
 
-      - name: Set contracts matrix
+      - name: Set contracts matrix (skip newly added libraries - no prior artifact to compare)
         id: set-matrix
         working-directory: packages/contracts
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          MODIFIED_LIBS: ${{ steps.changed-libraries.outputs.libraries_modified_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Only check modified libraries (not newly added ones)
+          # New libraries have no prior storage artifact to compare against
+          if [ -n "$MODIFIED_LIBS" ]; then
+            for DIAMOND_LIB in $MODIFIED_LIBS; do
+              echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+            done
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Problem
When a new contract or library is added to the repo, the storage layout check CI fails with:
`No workflow run found with an artifact named...`

This happens because the `foundry-storage-check` action looks for a prior storage artifact to compare against, but newly added contracts have no such artifact.

## Solution
Use `tj-actions/changed-files` output to distinguish **modified** files (which have prior artifacts) from **newly added** files (which don't). Only run the storage check on modified contracts/libraries, skipping newly added ones.

## Changes
- **core-contracts-storage-check.yml**: Changed from `contracts_all_changed_files` to `contracts_modified_files` for the matrix
- **diamond-storage-check.yml**: Changed from `libraries_all_changed_files` to `libraries_modified_files` for the matrix

## QA Scenarios
1. No storage updates → CI skipped → Passing
2. Storage update, no collision → Check runs → Passing
3. Storage update, collision → Check runs → Failing
4. New contract added → Excluded from matrix → CI skipped → Passing

Closes #972