### PR TITLE
fix(ci): skip storage-layout check for newly added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -31,11 +31,17 @@ jobs:
         working-directory: packages/contracts
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
-          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          # Use only modified files — newly added contracts have no prior baseline
+          # artifact, so foundry-storage-check would fail trying to compare against
+          # a non-existent previous run. New contracts are skipped via empty matrix.
+          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_modified_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
-          done
+          touch contracts.txt
+          if [ -n "$CHANGED_CONTRACTS" ]; then
+            for CONTRACT in "$CHANGED_CONTRACTS"; do
+              echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+            done
+          fi
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     outputs:
@@ -64,4 +70,3 @@ jobs:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -35,11 +35,17 @@ jobs:
         working-directory: packages/contracts
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
-          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          # Use only modified files — newly added libraries have no prior baseline
+          # artifact, so foundry-storage-check would fail trying to compare against
+          # a non-existent previous run. New libraries are skipped via empty matrix.
+          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_modified_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
-          done
+          touch contracts.txt
+          if [ -n "$CHANGED_LIBS" ]; then
+            for DIAMOND_LIB in "$CHANGED_LIBS"; do
+              echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+            done
+          fi
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     outputs:


### PR DESCRIPTION
## Summary

Fixes #972

### Bug

When a **new** contract or library is added in a PR, both
`core-contracts-storage-check.yml` and `diamond-storage-check.yml` fail
with:

```
Error: No workflow run found with an artifact named
  <branch>.<contract-path>-<ContractName>.json
```

This happens because the `foundry-storage-check` action needs a prior
baseline artifact to diff against. Newly added files have no such
baseline — the check is meaningless and always false-positive-fails.

### Root cause

Both workflows set the strategy matrix from
`contracts_all_changed_files` / `libraries_all_changed_files`, which
includes **added** files alongside modified ones. The `foundry-storage-check`
action then attempts to fetch a baseline artifact that was never
generated, causing a hard failure.

### Fix

Switch from `*_all_changed_files` to `*_modified_files` so that
newly-added files are excluded from the matrix. The existing guard on
`check_storage_layout`:

```yaml
if: ${{ needs.provide_contracts.outputs.matrix != '[]' && needs.provide_contracts.outputs.matrix != '' }}
```

then naturally skips the entire job when every changed file is a net-new
addition (empty matrix).

Also adds `touch contracts.txt` before each loop so `cat` never fails
when the variable is empty, preventing a secondary script error.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/core-contracts-storage-check.yml` | `contracts_all_changed_files` → `contracts_modified_files`; `touch contracts.txt` guard |
| `.github/workflows/diamond-storage-check.yml` | `libraries_all_changed_files` → `libraries_modified_files`; `touch contracts.txt` guard |

### Before / After

**Before** (PR adds `NewFacet.sol`):
1. Matrix: `["src/dollar/core/NewFacet.sol:NewFacet"]`
2. `foundry-storage-check` looks for previous artifact → **not found → CI fails** ❌

**After** (PR adds `NewFacet.sol`):
1. `contracts_modified_files` = `""` (file is added, not modified)
2. Matrix: `[]`
3. `check_storage_layout` is skipped → **CI passes** ✅

**Existing modified contracts** still go through the full storage diff as before.